### PR TITLE
Fixing Javadoc syntax problems (Fixes #15)

### DIFF
--- a/src/foodmood/FoodController.java
+++ b/src/foodmood/FoodController.java
@@ -52,7 +52,6 @@ public class FoodController implements Initializable {
     /**
      * Gives the user the option to add a food.
      *
-     * @param fileName
      */
     public void addFoods() {
 

--- a/src/foodmood/MoodController.java
+++ b/src/foodmood/MoodController.java
@@ -29,8 +29,8 @@ public class MoodController implements Initializable {
     /**
      * Initializes the controller class.
      *
-     * @param url
-     * @param rb
+     * @param url Document URL
+     * @param rb resource bundle
      */
     @Override
     public void initialize(URL url, ResourceBundle rb) {

--- a/src/testHarness/TestHarness.java
+++ b/src/testHarness/TestHarness.java
@@ -413,7 +413,7 @@ public class TestHarness {
     /**
      * Runs the application and tests
      *
-     * @param args
+     * @param args command line arguments
      */
     public static void main(String[] args) {
         logger.log(Level.INFO,

--- a/src/testHarness/TestLauncher.java
+++ b/src/testHarness/TestLauncher.java
@@ -18,6 +18,7 @@ import javafx.stage.WindowEvent;
  * <li> Pass the stage to TestHarness, which handles changing views.</li>
  * <li>3. Pass the view associated with the first test to TestHarness, which
  * then loads the view and its controller.</li>
+ * </ol>
  *
  * @author jsm158
  * @since M02-A03


### PR DESCRIPTION
There were some syntax errors in our JavaDoc comments that were causing JavaDoc generation to fail. 