### PR TITLE
MoodRecord and MoodRecordDAO, one design question

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -59,7 +59,9 @@ javac.source=1.8
 javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\
-    ${build.classes.dir}
+    ${build.classes.dir}:\
+    ${libs.junit_4.classpath}:\
+    ${libs.hamcrest.classpath}
 javac.test.processorpath=\
     ${javac.test.classpath}
 javadoc.additionalparam=

--- a/src/dao/ConnectionManager.java
+++ b/src/dao/ConnectionManager.java
@@ -1,33 +1,24 @@
 package dao;
 
-import java.sql.Connection;
-
 /**
  * Provides a connection to the application database.
+ *
+ * We chose to use files for storage, so this class returns the location of
+ * files, directories, and paths.
  *
  * @author jsm158
  *
  */
 public class ConnectionManager {
 
-    private static final String HOST = "";
-    private static final String USERNAME = "";
-    private static final String PASSWORD = "";
+    public static final String DATA_DIR = "data";
+    public static final String ACCOUNT_DATA_DIR = "accountData";
+    public static final String MOOD_RECORD_FILE = "moodRecords.txt";
 
     /**
      * Constructs a new ConnectionManager
      */
     public ConnectionManager() {
-    }
-
-    /**
-     * Returns a connection to the application database
-     *
-     * @return a database connection
-     * @throws dao.DaoException if there is an error connecting to the database
-     */
-    public Connection getConnection() throws DaoException {
-        return null;
     }
 
 }

--- a/src/dao/MoodRecordDao.java
+++ b/src/dao/MoodRecordDao.java
@@ -1,5 +1,6 @@
 package dao;
 
+import foodmood.Mood;
 import foodmood.MoodRecord;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -11,7 +12,6 @@ import java.nio.file.StandardOpenOption;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -26,7 +26,7 @@ import java.util.logging.Logger;
 public class MoodRecordDao {
 
     private final static String FILENAME_PATTERN = "%s_moods.txt";
-    private final HashMap<String, String> moodNames;
+    private final HashMap<Integer, String> moodNames;
 
     // index of fields in a line
     private final static int RECORDID = 0;
@@ -36,8 +36,17 @@ public class MoodRecordDao {
     private final static int VALUE = 4;
 
     public MoodRecordDao() {
-        // TODO Get the list of moods and their names
+
+        MoodDao dao;
         moodNames = new HashMap<>();
+
+        try {
+            dao = new MoodDao();
+            ArrayList<Mood> moods = dao.getAllMoods();
+            moods.forEach(mood -> moodNames.put(mood.getId(), mood.getMoodName()));
+        } catch (DaoException ex) {
+            Logger.getLogger(MoodRecordDao.class.getName()).log(Level.SEVERE, null, ex);
+        }
     }
 
     /**
@@ -83,7 +92,7 @@ public class MoodRecordDao {
      * @param moodId
      * @param value
      */
-    public void saveMoodRecord(String accountId, LocalDate date, String moodId, double value) {
+    public void saveMoodRecord(String accountId, LocalDate date, int moodId, double value) {
 
         BufferedWriter bw = null;
 
@@ -92,6 +101,7 @@ public class MoodRecordDao {
 
         String recordId = UUID.randomUUID().toString();
 
+        // TODO replace the empty string for moodId with the correct value once 
         MoodRecord record = new MoodRecord(recordId, accountId, date, moodId, "", value);
 
         try {
@@ -165,10 +175,9 @@ public class MoodRecordDao {
         return new MoodRecord(attributes[RECORDID],
                 attributes[ACCOUNTID],
                 LocalDate.parse(attributes[DATE]),
-                attributes[MOODID],
-                "",
+                Integer.parseInt(attributes[MOODID]),
+                moodNames.getOrDefault(attributes[MOODID], ""),
                 Double.parseDouble(attributes[VALUE]));
-
     }
 
     /**

--- a/src/dao/MoodRecordDao.java
+++ b/src/dao/MoodRecordDao.java
@@ -25,18 +25,15 @@ public class MoodRecordDao {
     private final static String FILENAME_PATTERN = "%s.txt";
     private final HashMap<String, String> moodNames;
 
-    // positions of parts of a mood record
-    private static enum Record {
-        RECORDID,
-        ACCOUNTID,
-        DATE,
-        MOODID,
-        MOODNAME,
-        VALUE
-    }
+    // index of fields in a line
+    private final static int RECORDID = 0;
+    private final static int ACCOUNTID = 1;
+    private final static int DATE = 2;
+    private final static int MOODID = 3;
+    private final static int VALUE = 4;
 
     public MoodRecordDao() {
-        
+
         // Get the list of moods and their names
         moodNames = new HashMap<>();
     }
@@ -115,16 +112,21 @@ public class MoodRecordDao {
      *
      * @param line a string with record information
      * @return the new MoodRecord
+     * @throws dao.DaoException if the string is not in the correct format
      */
-    private MoodRecord parseRecord(String line) {
+    protected MoodRecord parseRecord(String line) throws DaoException {
         String[] attributes = line.split(",");
 
-        return new MoodRecord(attributes[Record.RECORDID.ordinal()],
-                attributes[Record.ACCOUNTID.ordinal()],
-                LocalDate.parse(attributes[Record.DATE.ordinal()]),
-                attributes[Record.MOODID.ordinal()],
+        if (attributes.length != 5) {
+            throw new DaoException("Record was in invalid format");
+        }
+
+        return new MoodRecord(attributes[RECORDID],
+                attributes[ACCOUNTID],
+                LocalDate.parse(attributes[DATE]),
+                attributes[MOODID],
                 "",
-                Double.parseDouble(attributes[Record.VALUE.ordinal()]));
+                Double.parseDouble(attributes[VALUE]));
 
     }
 }

--- a/src/dao/MoodRecordDao.java
+++ b/src/dao/MoodRecordDao.java
@@ -101,7 +101,6 @@ public class MoodRecordDao {
 
         String recordId = UUID.randomUUID().toString();
 
-        // TODO replace the empty string for moodId with the correct value once 
         MoodRecord record = new MoodRecord(recordId, accountId, date, moodId, "", value);
 
         try {

--- a/src/dao/MoodRecordDao.java
+++ b/src/dao/MoodRecordDao.java
@@ -1,9 +1,15 @@
 package dao;
 
 import foodmood.MoodRecord;
-import java.sql.Connection;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -16,7 +22,23 @@ import java.util.UUID;
  */
 public class MoodRecordDao {
 
+    private final static String FILENAME_PATTERN = "%s.txt";
+    private final HashMap<String, String> moodNames;
+
+    // positions of parts of a mood record
+    private static enum Record {
+        RECORDID,
+        ACCOUNTID,
+        DATE,
+        MOODID,
+        MOODNAME,
+        VALUE
+    }
+
     public MoodRecordDao() {
+        
+        // Get the list of moods and their names
+        moodNames = new HashMap<>();
     }
 
     /**
@@ -27,9 +49,23 @@ public class MoodRecordDao {
      * @param endDate the end of the date range (inclusive)
      * @param accountId the ID of the account associated with the records
      * @return the list of mood records
+     * @throws dao.DaoException if the file could not be read
      */
-    public ArrayList<MoodRecord> getMoodRecords(Date startDate, Date endDate, int accountId) {
-        return null;
+    public ArrayList<MoodRecord> getMoodRecords(Date startDate, Date endDate, String accountId) throws DaoException {
+        ArrayList<MoodRecord> records = new ArrayList<>();
+        Path data = Paths.get(ConnectionManager.DATA_DIR, ConnectionManager.ACCOUNT_DATA_DIR, String.format(FILENAME_PATTERN, accountId));
+
+        if (Files.exists(data)) {
+            try (BufferedReader in = Files.newBufferedReader(data)) {
+                while (in != null) {
+
+                }
+            } catch (IOException ex) {
+                throw new DaoException("Could not read mood record file " + data.toAbsolutePath().toString(), ex);
+            }
+        }
+
+        return records;
     }
 
     /**
@@ -72,5 +108,23 @@ public class MoodRecordDao {
      */
     private UUID generateRecordId() throws DaoException {
         return null;
+    }
+
+    /**
+     * Returns a new MoodRecord by parsing information from a string
+     *
+     * @param line a string with record information
+     * @return the new MoodRecord
+     */
+    private MoodRecord parseRecord(String line) {
+        String[] attributes = line.split(",");
+
+        return new MoodRecord(attributes[Record.RECORDID.ordinal()],
+                attributes[Record.ACCOUNTID.ordinal()],
+                LocalDate.parse(attributes[Record.DATE.ordinal()]),
+                attributes[Record.MOODID.ordinal()],
+                "",
+                Double.parseDouble(attributes[Record.VALUE.ordinal()]));
+
     }
 }

--- a/src/foodmood/MoodRecord.java
+++ b/src/foodmood/MoodRecord.java
@@ -18,7 +18,7 @@ public class MoodRecord implements Quantifiable {
     private final String id;
     private final String accountId;
     private final LocalDate date;
-    private final String moodId;
+    private final int moodId;
     private final String name;
     private final double value;
 
@@ -32,7 +32,7 @@ public class MoodRecord implements Quantifiable {
      * @param moodName the associated mood's name
      * @param value the value entered by the user
      */
-    public MoodRecord(String id, String accountId, LocalDate date, String moodId, String moodName, double value) {
+    public MoodRecord(String id, String accountId, LocalDate date, int moodId, String moodName, double value) {
         this.id = id;
         this.accountId = accountId;
         this.date = date;
@@ -96,7 +96,7 @@ public class MoodRecord implements Quantifiable {
      *
      * @return the mood ID
      */
-    public String getMoodId() {
+    public int getMoodId() {
         return moodId;
     }
 

--- a/src/foodmood/MoodRecord.java
+++ b/src/foodmood/MoodRecord.java
@@ -1,81 +1,107 @@
 package foodmood;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 /**
- * Mood Record Class
+ * MoodRecord represents a mood value recorded by a user on a date.
  *
- * The food record class is what a user has entered for a mood.
+ * M02:
  *
  * @author aswecker
+ *
+ * M03-A04:
+ * @author jsm158
  */
+public class MoodRecord implements Quantifiable {
 
-public class MoodRecord {
-    private int id;
-    private int accountId;
-    private Date date;
-    private String mood;
-    
-    
+    private final String id;
+    private final String accountId;
+    private final LocalDate date;
+    private final String moodId;
+    private final String name;
+    private final double value;
+
     /**
-    * This is the default constructor for the Mood Record Class.
-    * @param id the id number of the mood
-    * @param accountId the account number of the user
-    * @param date the date the mood was logged
-    * @param mood the mood the user logged
-    */ 
-    public MoodRecord(int id, int accountId, Date date, String mood){
+     * This is the default constructor for the Mood Record Class.
+     *
+     * @param id the id number of the mood
+     * @param accountId the account number of the user
+     * @param date the date the mood was logged
+     * @param moodId the associated mood's ID
+     * @param moodName the associated mood's name
+     * @param value the value entered by the user
+     */
+    public MoodRecord(String id, String accountId, LocalDate date, String moodId, String moodName, double value) {
         this.id = id;
         this.accountId = accountId;
         this.date = date;
-        this.mood = mood;
+        this.moodId = moodId;
+        this.name = moodName;
+        this.value = value;
     }
-    
+
     /**
-    * Returns the mood ID
-    * @return An integer for the mood ID
-    */ 
-    public int getId(){
+     * Returns the mood ID
+     *
+     * @return the mood ID
+     */
+    public String getId() {
         return id;
     }
-    
-    public void setId(int id){
-        this.id=id;
-    }
-    
+
     /**
-    * Returns the date
-    * @return the date the user logged a mood
-    */ 
-    public int getAccountId(){
+     * Returns ID of the user account that logged the mood
+     *
+     * @return the account ID
+     */
+    public String getAccountId() {
         return accountId;
     }
-    
-    public void setAccountId(int accountId){
-        this.accountId=accountId;
-    }
-    
+
     /**
-    * Returns the date
-    * @return the date a user logged a mood
-    */ 
-    public Date getDate(){
+     * Returns the date the mood was recorded
+     *
+     * @return the date a user logged a mood
+     */
+    @Override
+    public LocalDate getDate() {
         return date;
     }
-    
-    public void setDate(Date date){
-        this.date=date;
-    }
-    
+
     /**
-    * Returns the mood name
-    * @return A string of the mood name
-    */ 
-    public String getMood(){
-        return mood;
+
+    /**
+     * Returns the associated mood name
+     *
+     * @return A string of the mood name
+     */
+    @Override
+    public String getName() {
+        return name;
     }
-    
-    public void setMood(String mood){
-        this.mood=mood;
+
+    /**
+     * Returns the value logged for the mood
+     *
+     * @return the value
+     */
+    @Override
+    public double getValue() {
+        return value;
     }
+
+    /**
+     * Returns the ID of the associated mood
+     *
+     * @return the mood ID
+     */
+    public String getMoodId() {
+        return moodId;
+    }
+
+    @Override
+    public String getTypeId() {
+        return getMoodId();
+    }
+
 }

--- a/src/foodmood/MoodRecord.java
+++ b/src/foodmood/MoodRecord.java
@@ -1,6 +1,7 @@
 package foodmood;
 
 import java.time.LocalDate;
+import java.util.Objects;
 
 /**
  * MoodRecord represents a mood value recorded by a user on a date.
@@ -69,8 +70,8 @@ public class MoodRecord implements Quantifiable {
     }
 
     /**
-
-    /**
+     *
+     * /**
      * Returns the associated mood name
      *
      * @return A string of the mood name
@@ -97,5 +98,22 @@ public class MoodRecord implements Quantifiable {
      */
     public String getMoodId() {
         return moodId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (MoodRecord.class.isAssignableFrom(o.getClass())) {
+            MoodRecord m = (MoodRecord) o;
+            return (this.id.equals(m.id));
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 59 * hash + Objects.hashCode(this.id);
+        return hash;
     }
 }

--- a/src/foodmood/MoodRecord.java
+++ b/src/foodmood/MoodRecord.java
@@ -98,10 +98,4 @@ public class MoodRecord implements Quantifiable {
     public String getMoodId() {
         return moodId;
     }
-
-    @Override
-    public String getTypeId() {
-        return getMoodId();
-    }
-
 }

--- a/src/foodmood/Quantifiable.java
+++ b/src/foodmood/Quantifiable.java
@@ -1,0 +1,46 @@
+package foodmood;
+
+import java.time.LocalDate;
+
+/**
+ * The Quantifiable interface defines the data needed for an object to be
+ * displayed on a line graph or chart.
+ *
+ * Every Quantifiable object needs a display name, date, and a numeric value.
+ * The numeric value will be plotted as a measure.
+ *
+ * @author jsm158
+ * @since M03-A04
+ */
+public interface Quantifiable {
+
+    /**
+     * Returns the date on which the item was recorded
+     *
+     * @return the record date
+     */
+    public LocalDate getDate();
+
+    /**
+     * Returns the name of the item recorded
+     *
+     * @return
+     */
+    public String getName();
+
+    /**
+     * Returns the ID of the item recorded
+     *
+     * i.e. the ID of the mood or food
+     *
+     * @return the ID of the mood or food
+     */
+    public int getTypeId();
+
+    /**
+     * Returns the numeric value of the item recorded
+     *
+     * @return
+     */
+    public double getValue();
+}

--- a/src/foodmood/Quantifiable.java
+++ b/src/foodmood/Quantifiable.java
@@ -29,15 +29,6 @@ public interface Quantifiable {
     public String getName();
 
     /**
-     * Returns the ID of the item recorded
-     *
-     * i.e. the ID of the mood or food
-     *
-     * @return the ID of the mood or food
-     */
-    public String getTypeId();
-
-    /**
      * Returns the numeric value of the item recorded
      *
      * @return

--- a/src/foodmood/Quantifiable.java
+++ b/src/foodmood/Quantifiable.java
@@ -35,7 +35,7 @@ public interface Quantifiable {
      *
      * @return the ID of the mood or food
      */
-    public int getTypeId();
+    public String getTypeId();
 
     /**
      * Returns the numeric value of the item recorded

--- a/test/dao/MoodRecordDaoTest.java
+++ b/test/dao/MoodRecordDaoTest.java
@@ -16,7 +16,9 @@ import org.junit.BeforeClass;
 
 /**
  *
- * @author redjen
+ * Tests for MoodRecordDao
+ *
+ * @author jsm158
  */
 public class MoodRecordDaoTest {
 

--- a/test/dao/MoodRecordDaoTest.java
+++ b/test/dao/MoodRecordDaoTest.java
@@ -1,12 +1,18 @@
 package dao;
 
 import foodmood.MoodRecord;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.Month;
-import org.junit.After;
+import java.util.ArrayList;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.BeforeClass;
 
 /**
  *
@@ -21,51 +27,94 @@ public class MoodRecordDaoTest {
     private final static String TEST1_MOOD_ID = "mood1";
     private final static String TEST1_MOOD_NAME = "name 1";
     private final static double TEST1_VALUE = 3.5;
-    
+
+    private final static Path TEST_DATA_FILE = Paths.get("test", "dao", "MoodRecordDaoTestData.txt");
+    private final static Path DATA_DIR = Paths.get("data", "accountData");
 
     public MoodRecordDaoTest() {
     }
 
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         dao = new MoodRecordDao();
     }
 
-    @After
-    public void tearDown() {
+    @BeforeClass
+    public static void setUpClass() throws IOException {
+        Files.createDirectories(DATA_DIR);
+        Files.copy(TEST_DATA_FILE, DATA_DIR.resolve("account1_moods.txt"));
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws IOException {
+        Files.deleteIfExists(DATA_DIR.resolve("account1_moods.txt"));
+        Files.deleteIfExists(DATA_DIR.resolve("account2_moods.txt"));
     }
 
     @Test
-    public void testGetMoodRecords_3args() throws Exception {
+    public void testGetMoodRecordsBetweenDates() throws Exception {
+
+        ArrayList<MoodRecord> records = dao.getMoodRecords(LocalDate.of(2017, Month.MAY, 1),
+                LocalDate.of(2017, Month.JUNE, 1), "account1");
+
+        assertEquals(2, records.size());
+        assertEquals("test2", records.get(0).getId());
+        assertEquals("test3", records.get(1).getId());
     }
 
     @Test
-    public void testGetMoodRecords_Date_Date() {
+    public void testGetMoodRecordsBetweenDatesNone() throws Exception {
+        ArrayList<MoodRecord> records = dao.getMoodRecords(LocalDate.of(2018, Month.MAY, 1),
+                LocalDate.of(2020, Month.JUNE, 1), "account1");
+
+        assertEquals(0, records.size());
     }
 
     @Test
-    public void testSaveMoodRecord() {
+    public void testGetAllMoodRecords() throws Exception {
+        ArrayList<MoodRecord> records = dao.getMoodRecords(LocalDate.of(2017, Month.JANUARY, 1),
+                LocalDate.of(2017, Month.DECEMBER, 31), "account1");
+
+        assertEquals(4, records.size());
+        assertEquals("test1", records.get(0).getId());
+        assertEquals("test2", records.get(1).getId());
+        assertEquals("test3", records.get(2).getId());
+        assertEquals("test4", records.get(3).getId());
     }
 
     @Test
-    public void testSaveMoodRecords() {
+    public void testSaveMoodRecord() throws DaoException {
+        ArrayList<MoodRecord> records;
+
+        dao.saveMoodRecord("account2", LocalDate.now(), TEST1_MOOD_ID, 1.1);
+        records = dao.getMoodRecords(LocalDate.of(2017, Month.JANUARY, 1),
+                LocalDate.of(2017, Month.DECEMBER, 31), "account2");
+        assertEquals(1, records.size());
+
+        dao.saveMoodRecord("account2", LocalDate.now(), TEST1_MOOD_ID, 1.2);
+        records = dao.getMoodRecords(LocalDate.of(2017, Month.JANUARY, 1),
+                LocalDate.of(2017, Month.DECEMBER, 31), "account2");
+        assertEquals(2, records.size());
+        assertEquals(1.1, records.get(0).getValue(), 0);
+        assertEquals(1.2, records.get(1).getValue(), 0);
+
     }
 
     @Test
     public void testParseRecord() throws DaoException {
-        String testRecord = String.format("%s,%s,%s,%s,%f", 
+        String testRecord = String.format("%s,%s,%s,%s,%f",
                 TEST1_RECORD_ID,
                 TEST1_ACCOUNT_ID,
                 TEST1_DATE,
                 TEST1_MOOD_ID,
                 TEST1_VALUE);
-        
+
         MoodRecord record = dao.parseRecord(testRecord);
         assertEquals(TEST1_ACCOUNT_ID, record.getAccountId());
         assertEquals(TEST1_DATE, record.getDate().toString());
         assertEquals(TEST1_MOOD_ID, record.getMoodId());
         assertEquals(TEST1_VALUE, record.getValue(), 0);
-        
+
     }
 
     @Test(expected = DaoException.class)
@@ -76,5 +125,13 @@ public class MoodRecordDaoTest {
     @Test(expected = DaoException.class)
     public void testParseRecordBad() throws DaoException {
         dao.parseRecord("test,test");
+    }
+
+    @Test
+    public void testWriteRecord() {
+        MoodRecord record = new MoodRecord(TEST1_RECORD_ID, TEST1_ACCOUNT_ID, LocalDate.parse(TEST1_DATE), TEST1_MOOD_ID, TEST1_MOOD_NAME, TEST1_VALUE);
+        String expected = String.format("%s,%s,%s,%s,%.1f",
+                TEST1_RECORD_ID, TEST1_ACCOUNT_ID, TEST1_DATE, TEST1_MOOD_ID, TEST1_VALUE);
+        assertEquals(expected, dao.writeRecord(record));
     }
 }

--- a/test/dao/MoodRecordDaoTest.java
+++ b/test/dao/MoodRecordDaoTest.java
@@ -1,0 +1,80 @@
+package dao;
+
+import foodmood.MoodRecord;
+import java.time.LocalDate;
+import java.time.Month;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author redjen
+ */
+public class MoodRecordDaoTest {
+
+    private MoodRecordDao dao;
+    private final static String TEST1_RECORD_ID = "test1";
+    private final static String TEST1_ACCOUNT_ID = "account1";
+    private final static String TEST1_DATE = LocalDate.of(2017, Month.APRIL, 1).toString();
+    private final static String TEST1_MOOD_ID = "mood1";
+    private final static String TEST1_MOOD_NAME = "name 1";
+    private final static double TEST1_VALUE = 3.5;
+    
+
+    public MoodRecordDaoTest() {
+    }
+
+    @Before
+    public void setUp() {
+        dao = new MoodRecordDao();
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testGetMoodRecords_3args() throws Exception {
+    }
+
+    @Test
+    public void testGetMoodRecords_Date_Date() {
+    }
+
+    @Test
+    public void testSaveMoodRecord() {
+    }
+
+    @Test
+    public void testSaveMoodRecords() {
+    }
+
+    @Test
+    public void testParseRecord() throws DaoException {
+        String testRecord = String.format("%s,%s,%s,%s,%f", 
+                TEST1_RECORD_ID,
+                TEST1_ACCOUNT_ID,
+                TEST1_DATE,
+                TEST1_MOOD_ID,
+                TEST1_VALUE);
+        
+        MoodRecord record = dao.parseRecord(testRecord);
+        assertEquals(TEST1_ACCOUNT_ID, record.getAccountId());
+        assertEquals(TEST1_DATE, record.getDate().toString());
+        assertEquals(TEST1_MOOD_ID, record.getMoodId());
+        assertEquals(TEST1_VALUE, record.getValue(), 0);
+        
+    }
+
+    @Test(expected = DaoException.class)
+    public void testParseRecordEmpty() throws DaoException {
+        dao.parseRecord("");
+    }
+
+    @Test(expected = DaoException.class)
+    public void testParseRecordBad() throws DaoException {
+        dao.parseRecord("test,test");
+    }
+}

--- a/test/dao/MoodRecordDaoTestData.txt
+++ b/test/dao/MoodRecordDaoTestData.txt
@@ -1,0 +1,4 @@
+test1,account1,2017-04-01,mood1,3.5
+test2,account1,2017-05-01,mood2,1.5
+test3,account1,2017-06-01,mood3,3.0
+test4,account1,2017-07-01,mood4,5.0

--- a/test/foodmood/MoodRecordTest.java
+++ b/test/foodmood/MoodRecordTest.java
@@ -57,4 +57,21 @@ public class MoodRecordTest {
         assertEquals(MOODID, record.getMoodId());
     }
 
+    @Test
+    public void testEquals() {
+        MoodRecord record2 = new MoodRecord(ID, "test", LocalDate.now(), "test", "test", 1.0);
+        assertEquals(record, record2);
+    }
+
+    @Test
+    public void testNotEquals() {
+        MoodRecord record2 = new MoodRecord("test", "test", LocalDate.now(), "test", "test", 1.0);
+        assertNotEquals(record, record2);
+    }
+
+    @Test
+    public void testNotEqualsObject() {
+        assertNotEquals(record, new Object());
+    }
+
 }

--- a/test/foodmood/MoodRecordTest.java
+++ b/test/foodmood/MoodRecordTest.java
@@ -1,0 +1,60 @@
+package foodmood;
+
+import java.time.LocalDate;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for MoodRecord model class
+ *
+ * @author jsm158
+ */
+public class MoodRecordTest {
+
+    private MoodRecord record;
+    private final static String ID = "record1";
+    private final static String ACCOUNT = "account1";
+    private final static String MOODID = "mood1";
+    private final static String MOODNAME = "moodname1";
+    private final static double VALUE = 1.0;
+
+    public MoodRecordTest() {
+    }
+
+    @Before
+    public void setUp() {
+        record = new MoodRecord(ID, ACCOUNT, LocalDate.now(), MOODID, MOODNAME, VALUE);
+    }
+
+    @Test
+    public void testGetId() {
+        assertEquals(ID, record.getId());
+    }
+
+    @Test
+    public void testGetAccountId() {
+        assertEquals(ACCOUNT, record.getAccountId());
+    }
+
+    @Test
+    public void testGetDate() {
+        assertEquals(LocalDate.now(), record.getDate());
+    }
+
+    @Test
+    public void testGetName() {
+        assertEquals(MOODNAME, record.getName());
+    }
+
+    @Test
+    public void testGetValue() {
+        assertEquals(VALUE, record.getValue(), 0);
+    }
+
+    @Test
+    public void testGetMoodId() {
+        assertEquals(MOODID, record.getMoodId());
+    }
+
+}


### PR DESCRIPTION
This has the model class for mood records and the DAO to read/write them. Both classes have tests (which all pass). Once merged the app will support reading and writing records.

I wasn't sure about how to handle the mood name field. The record has the mood ID, which is the immutable unique ID of a mood. However, we also had the mood name (corresponding to the ID) as well. I realized this would be good to keep for performance because we wouldn't need to look up the mood name for each record when displaying a table or graph. However, this comes at the cost of needing to look up the name when reading the data from file. Which should we do? I lean toward adding the name when reading from file because the user is less likely to notice the performance hit from reading the list than the one when displaying data.

The Quantifiable interface is there because it's needed for the implementation of my design pattern. It's an interface that specifies the data/methods a model class needs to have in order to be displayed in a chart.